### PR TITLE
Make minitest output compatible with natural language case naming

### DIFF
--- a/demo/test_autorun_minitest.rb
+++ b/demo/test_autorun_minitest.rb
@@ -1,6 +1,8 @@
 require 'minitest/unit'
 require 'turn'
 
+MiniTest::Unit.use_natural_language_case_names = true
+
 class SampleCase1 < MiniTest::Unit::TestCase
   def test_sample_pass1
     assert_equal(1,1)

--- a/lib/turn/autorun/minitest.rb
+++ b/lib/turn/autorun/minitest.rb
@@ -7,6 +7,16 @@ class MiniTest::Unit
   include ANSI::Code
 
   PADDING_SIZE = 4
+  
+  @@use_natural_language_case_names = false
+  def self.use_natural_language_case_names=(boolean)
+    @use_natural_language_case_names = boolean
+  end
+  
+  def self.use_natural_language_case_names?
+    @use_natural_language_case_names
+  end
+  
 
   def run(args = [])
     @verbose = true
@@ -16,9 +26,11 @@ class MiniTest::Unit
                arg = args.shift
                if arg =~ /\/(.*)\//
                  Regexp.new($1)
-               else
+               elsif MiniTest::Unit.use_natural_language_case_names?
                  # Turn 'sample error1' into 'test_sample_error1'
                  arg[0..4] == "test_" ? arg.gsub(" ", "_") : "test_" + arg.gsub(" ", "_")
+               else
+                 arg
                end
              else
                /./ # anything - ^test_ already filtered by #tests
@@ -78,7 +90,8 @@ class MiniTest::Unit
                     end)
 
 
-        @@out.print " #{test.gsub("test_", "").gsub(/_/, " ")}"
+        @@out.print MiniTest::Unit.use_natural_language_case_names? ? 
+          " #{test.gsub("test_", "").gsub(/_/, " ")}" : " #{test}"
         @@out.print " (%.2fs) " % (Time.now - t)
 
         if @broken

--- a/lib/turn/autorun/minitest.rb
+++ b/lib/turn/autorun/minitest.rb
@@ -14,7 +14,12 @@ class MiniTest::Unit
     filter = if args.first =~ /^(-n|--name)$/ then
                args.shift
                arg = args.shift
-               arg =~ /\/(.*)\// ? Regexp.new($1) : arg
+               if arg =~ /\/(.*)\//
+                 Regexp.new($1)
+               else
+                 # Turn 'sample error1' into 'test_sample_error1'
+                 arg[0..4] == "test_" ? arg.gsub(" ", "_") : "test_" + arg.gsub(" ", "_")
+               end
              else
                /./ # anything - ^test_ already filtered by #tests
              end
@@ -73,7 +78,7 @@ class MiniTest::Unit
                     end)
 
 
-        @@out.print " #{test}"
+        @@out.print " #{test.gsub("test_", "").gsub(/_/, " ")}"
         @@out.print " (%.2fs) " % (Time.now - t)
 
         if @broken

--- a/turn.gemspec
+++ b/turn.gemspec
@@ -1,0 +1,49 @@
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |s|
+  s.name = %q{turn}
+  s.version = "0.8.1"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.authors = ["Tim Pease"]
+  s.date = %q{2010-09-09}
+  s.default_executable = %q{turn}
+  s.description = %q{TURN is a new way to view Test::Unit results. With longer running tests, it
+can be very frustrating to see a failure (....F...) and then have to wait till
+all the tests finish before you can see what the exact failure was. TURN
+displays each test on a separate line with failures being displayed
+immediately instead of at the end of the tests.
+
+If you have the 'ansi' gem installed, then TURN output will be displayed in
+wonderful technicolor (but only if your terminal supports ANSI color codes).
+Well, the only colors are green and red, but that is still color.}
+  s.email = %q{tim.pease@gmail.com}
+  s.executables = ["turn"]
+  s.extra_rdoc_files = ["History.txt", "README.txt", "Release.txt", "Version.txt", "bin/turn"]
+  s.files = ["History.txt", "README.txt", "Rakefile", "Release.txt", "Version.txt", "bin/turn", "demo/test_autorun_minitest.rb", "demo/test_autorun_testunit.rb", "demo/test_sample.rb", "demo/test_sample2.rb", "lib/turn.rb", "lib/turn/autorun/minitest.rb", "lib/turn/autorun/testunit.rb", "lib/turn/bin.rb", "lib/turn/colorize.rb", "lib/turn/command.rb", "lib/turn/components/case.rb", "lib/turn/components/method.rb", "lib/turn/components/suite.rb", "lib/turn/controller.rb", "lib/turn/core_ext.rb", "lib/turn/reporter.rb", "lib/turn/reporters/cue_reporter.rb", "lib/turn/reporters/dot_reporter.rb", "lib/turn/reporters/marshal_reporter.rb", "lib/turn/reporters/outline_reporter.rb", "lib/turn/reporters/pretty_reporter.rb", "lib/turn/reporters/progress_reporter.rb", "lib/turn/runners/crossrunner.rb", "lib/turn/runners/isorunner.rb", "lib/turn/runners/loadrunner.rb", "lib/turn/runners/minirunner.rb", "lib/turn/runners/solorunner.rb", "lib/turn/runners/testrunner.rb", "test/helper.rb", "test/runner", "test/test_framework.rb", "test/test_reporters.rb", "test/test_runners.rb"]
+  s.homepage = %q{http://gemcutter.org/gems/turn}
+  s.rdoc_options = ["--main", "README.txt"]
+  s.require_paths = ["lib"]
+  s.rubyforge_project = %q{codeforpeople}
+  s.rubygems_version = %q{1.5.2}
+  s.summary = %q{Test::Unit Reporter (New) -- new output format for Test::Unit}
+  s.test_files = ["test/test_framework.rb", "test/test_reporters.rb", "test/test_runners.rb"]
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 3
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<ansi>, [">= 1.2.2"])
+      s.add_development_dependency(%q<bones-git>, [">= 1.2.0"])
+      s.add_development_dependency(%q<bones>, [">= 3.4.7"])
+    else
+      s.add_dependency(%q<ansi>, [">= 1.2.2"])
+      s.add_dependency(%q<bones-git>, [">= 1.2.0"])
+      s.add_dependency(%q<bones>, [">= 3.4.7"])
+    end
+  else
+    s.add_dependency(%q<ansi>, [">= 1.2.2"])
+    s.add_dependency(%q<bones-git>, [">= 1.2.0"])
+    s.add_dependency(%q<bones>, [">= 3.4.7"])
+  end
+end


### PR DESCRIPTION
In Rails, we recommend the test "something with spaces" do/end way of naming test cases. It would be wonderful if it was possible to echo that naming scheme in the test output. That would make it easier to search for failing tests as well.
