### PR TITLE
Fix for gvim not supporting ANSI

### DIFF
--- a/lib/turn/colorize.rb
+++ b/lib/turn/colorize.rb
@@ -12,7 +12,8 @@ module Turn
 
   module Colorize
 
-    COLORIZE = defined?(::ANSI::Code) && ENV.has_key?('TERM')
+    COLORLESS_TERMINALS = ['dumb']	
+    COLORIZE = defined?(::ANSI::Code) && ENV.has_key?('TERM') && !COLORLESS_TERMINALS.include?(ENV['TERM'])
 
     def self.red(string)
       COLORIZE ? ::ANSI::Code.red{ string } : string


### PR DESCRIPTION
Hello,

gvim, a popular VIM based editor for Gnome, does not support ANSI output in scripts. This means that if turn is used in combination with gvim, ansi codes will litter the output. The reason for this is that gvim sets the TERM environment variable to 'dumb' instead of unsetting it. There are a number of ways to deal with this, of course, but the attached patch simply modifies the current code to check if the TERM environment variable is part of a disallowed set before using color - currently, only the 'dumb' value set by gvim is in the list. This does not effect tests run from a VIM session inside of a terminal emulator such as xterm, nor does it effect tests run directly from the command line. (Although my desktop uses Linux and thus gvim, a quick test shows that MacVim - the equivalent graphical Vim for the Mac OS X operating system - has identical behaviour.)

Anyway, this patch significantly increases usability for gvim+rails.vim users, and so I would really appreciate it's incorporation.

Thank you for your consideration and your time,

David Berube
