### PR TITLE
Add -t or --trace option for display full stacktrace.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage
 doc
 pkg
 tmp
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'http://rubygems.org'
+gem 'bones'

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'http://rubygems.org'
 gem 'bones'
+gem 'ansi', ">=1.2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    ansi (1.2.5)
     bones (3.6.5)
       little-plugger (>= 1.1.2)
       loquacious (>= 1.7.0)
@@ -13,4 +14,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ansi (>= 1.2.2)
   bones

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    bones (3.6.5)
+      little-plugger (>= 1.1.2)
+      loquacious (>= 1.7.0)
+      rake (>= 0.8.7)
+    little-plugger (1.1.2)
+    loquacious (1.7.1)
+    rake (0.8.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bones

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,17 @@
+require 'rubygems'
+
+gemfile = File.expand_path('../Gemfile', __FILE__)
 begin
-  require 'bones'
-rescue LoadError
-  abort '### please install the "bones" gem ###'
-end
+  ENV['BUNDLE_GEMFILE'] = gemfile
+  require 'bundler'
+  Bundler.setup
+rescue Bundler::GemNotFound => e
+  STDERR.puts e.message
+  STDERR.puts "Try running `bundle install`."
+  exit!
+end if File.exist?(gemfile)
+
+require 'bones'
 
 task :default => 'test'
 

--- a/lib/turn/autorun/minitest.rb
+++ b/lib/turn/autorun/minitest.rb
@@ -20,7 +20,7 @@ class MiniTest::Unit
 
   def run(args = [])
     @verbose = true
-    options = args.getopts("n:t", "name:", "trace")
+    options = args.getopts("n:d", "name:", "debug")
     filter = if name = options["n"] || options["name"]
                if name =~ /\/(.*)\//
                  Regexp.new($1)
@@ -34,7 +34,7 @@ class MiniTest::Unit
                /./ # anything - ^test_ already filtered by #tests
              end
 
-    @trace = options['t'] || options['trace']
+    @debug = options['d'] || options['debug']
 
     @@out.puts "Loaded suite #{$0.sub(/\.rb$/, '')}\nStarted"
 
@@ -101,7 +101,7 @@ class MiniTest::Unit
           @@out.puts pad(report[:message], 10)
 
           trace = MiniTest::filter_backtrace(report[:exception].backtrace)
-          if @trace
+          if @debug
             @@out.print trace.map{|t| pad(t, 10) }.join("\n")
           else
             @@out.print pad(trace.first, 10)

--- a/lib/turn/components/method.rb
+++ b/lib/turn/components/method.rb
@@ -12,27 +12,38 @@ module Turn
       @name      = name
       @fail      = false
       @error     = false
+      @skip      = false
       @raised    = nil
       @message   = nil
       @backtrace = []
     end
 
     def fail!(assertion)
-      @fail, @error = true, false
+      @fail, @error, @skip = true, false, false
       @raised    = assertion
       @message   = assertion.message
       @backtrace = assertion.backtrace
     end
 
     def error!(exception)
-      @fail, @error = false, true
+      @fail, @error, @skip = false, true, false
       @raised    = exception
       @message   = exception.message
       @backtrace = exception.backtrace
     end
 
+    def skip!(assertion)
+      @fail, @error, @skip = false, false, true
+      @raised    = assertion
+      @message   = assertion.message
+      @backtrace = assertion.backtrace
+    end
+
     def fail?  ; @fail  ; end
     def error? ; @error ; end
+    def skip?  ; @skip  ; end
+
+    # TODO: should this include `or @skip`?
     def pass?  ; !(@fail or @error) ; end
 
     def to_s ; name ; end

--- a/lib/turn/runners/minirunner.rb
+++ b/lib/turn/runners/minirunner.rb
@@ -5,7 +5,7 @@ debug, $DEBUG = $DEBUG, false
 require 'minitest/unit'
 $DEBUG = debug
 
-Test = MiniTest
+autoload "Test", 'test/unit' #Test = MiniTest
 
 module Turn
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -90,3 +90,18 @@ end
   save_test(text, 'minitest_autorun_test.rb')
 end
 
+
+def setup_minitest_autorun_with_fail
+  text = <<-HERE
+require 'minitest/unit'
+require 'rubygems'
+require 'turn'
+MiniTest::Unit.autorun
+class TestTest < MiniTest::Unit::TestCase
+  def test_sample_pass
+    assert_equal(0,1)
+  end
+end
+  HERE
+  save_test(text, 'minitest_autorun_test_with_fail.rb')
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,10 +1,5 @@
 require 'fileutils'
-
-if RUBY_VERSION < "1.9"
-  require 'test/unit'
-else
-  require 'minitest/unit'
-end
+require 'test/unit'
 
 #
 def turn(*args)

--- a/test/test_framework.rb
+++ b/test/test_framework.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper.rb'
+require File.dirname(File.expand_path(__FILE__)) + '/helper.rb'
 
 # Test on Ruby 1.9+
 if RUBY_VERSION >= '1.9'

--- a/test/test_reporters.rb
+++ b/test/test_reporters.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper.rb'
+require File.dirname(File.expand_path(__FILE__)) + '/helper.rb'
 
 class TestReporters < Test::Unit::TestCase
 

--- a/test/test_reporters.rb
+++ b/test/test_reporters.rb
@@ -3,7 +3,6 @@ require File.dirname(File.expand_path(__FILE__)) + '/helper.rb'
 class TestReporters < Test::Unit::TestCase
 
   begin
-    require 'ansi'
     def test_progress
       file = setup_test('Test')
       result = turn '--progress', file

--- a/test/test_runners.rb
+++ b/test/test_runners.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper.rb'
+require File.dirname(File.expand_path(__FILE__)) + '/helper.rb'
 
 class TestRunners < Test::Unit::TestCase
 

--- a/test/test_runners.rb
+++ b/test/test_runners.rb
@@ -39,7 +39,18 @@ class TestRunners < Test::Unit::TestCase
       assert result.index('0 errors')
     end
 
-  end
+    def test_autorun_with_fail
+      file = setup_minitest_autorun_with_fail
+      result = `ruby -Ilib #{file} --trace 2>&1`
+      assert result.index('1 failures')
+      assert result.index('0 errors')
+      assert result.scan(/\.rb:\d+:in/).length > 1
 
+      result = `ruby -Ilib #{file} -t 2>&1`
+      assert result.index('1 failures')
+      assert result.index('0 errors')
+      assert result.scan(/\.rb:\d+:in/).length > 1
+    end
+  end
 end
 

--- a/test/test_runners.rb
+++ b/test/test_runners.rb
@@ -41,12 +41,12 @@ class TestRunners < Test::Unit::TestCase
 
     def test_autorun_with_fail
       file = setup_minitest_autorun_with_fail
-      result = `ruby -Ilib #{file} --trace 2>&1`
+      result = `ruby -Ilib #{file} --debug 2>&1`
       assert result.index('1 failures')
       assert result.index('0 errors')
       assert result.scan(/\.rb:\d+:in/).length > 1
 
-      result = `ruby -Ilib #{file} -t 2>&1`
+      result = `ruby -Ilib #{file} -d 2>&1`
       assert result.index('1 failures')
       assert result.index('0 errors')
       assert result.scan(/\.rb:\d+:in/).length > 1


### PR DESCRIPTION
Hi TwP.

I want to display full stack trace when test is failure or error.
I tried to add the options t or trace to be able to it.

Please consider merge in this fix.

Thanks.
