### PR TITLE
Make Turn work with gems that monkey-patch MiniTest::Unit::TestCase.run()

### DIFF
--- a/lib/turn/autorun/minitest.rb
+++ b/lib/turn/autorun/minitest.rb
@@ -74,7 +74,7 @@ class MiniTest::Unit
 
         @broken = nil
 
-        @@out.print(case inst.run(self)
+        @@out.print(case run_testcase(inst, self)
                     when :pass
                       @broken = false
                       green { pad_with_size "PASS" }
@@ -150,28 +150,15 @@ class MiniTest::Unit
     result
   end
 
-
-  class TestCase
-    # Overwrite #run method so that is uses symbols
-    # as return values rather than characters.
-    def run(runner)
-      result = :pass
-      begin
-        @passed = nil
-        self.setup
-        self.__send__ self.__name__
-        @passed = true
-      rescue Exception => e
-        @passed = false
-        result = runner.puke(self.class, self.__name__, e)
-      ensure
-        begin
-          self.teardown
-        rescue Exception => e
-          result = runner.puke(self.class, self.__name__, e)
-        end
-      end
-      result
+private
+  # A wrapper over MiniTest::Unit::TestCase.run() that returns
+  # :pass whenever the test succeeds (i.e. run() returns "" or ".")
+  def run_testcase(testcase, runner)
+    original_result = testcase.run(runner)
+    if original_result == "" || original_result == "."
+        :pass
+    else
+        original_result
     end
   end
 end

--- a/lib/turn/command.rb
+++ b/lib/turn/command.rb
@@ -16,6 +16,7 @@ module Turn
   #   -I --loadpath=PATHS   add given PATHS to the $LOAD_PATH
   #   -r --requires=LIBS    require given LIBS before running tests
   #   -m --minitest         Force use of MiniTest framework.
+  #   -t --trace            Turn on invoke/execute tracing, enable full backtrace.
   #
   # RUN MODES
   #      --normal      run all tests in a single process [default]
@@ -64,6 +65,9 @@ module Turn
     # Output mode.
     attr :outmode
 
+    # Enable full backtrace
+    attr :trace
+
     #
     def initialize
       @live      = nil
@@ -75,6 +79,7 @@ module Turn
       @runmode   = nil
       @outmode   = nil
       @framework = RUBY_VERSION >= "1.9" ? :minitest : :testunit
+      @trace     = nil
     end
 
     #
@@ -116,6 +121,10 @@ module Turn
 
         opts.on('-m', '--minitest', "Force use of MiniTest framework") do
           @framework = :minitest
+        end
+
+        opts.on("-t", '--trace', "Turn on invoke/execute tracing, enable full backtrace") do
+          @trace = true
         end
 
         # Turn does not support Test::Unit 2.0+
@@ -216,6 +225,7 @@ module Turn
         c.pattern   = pattern
         c.matchcase = matchcase
         c.framework = framework
+        c.trace     = trace
       end
 
       result = controller.start

--- a/lib/turn/controller.rb
+++ b/lib/turn/controller.rb
@@ -168,7 +168,7 @@ module Turn
           Turn::DotReporter.new($stdout, :trace => @trace)
         when :pretty
           require 'turn/reporters/pretty_reporter'
-          Turn::PrettyReporter.new($stdout)
+          Turn::PrettyReporter.new($stdout, :trace => @trace)
         when :cue
           require 'turn/reporters/cue_reporter'
           Turn::CueReporter.new($stdout)

--- a/lib/turn/controller.rb
+++ b/lib/turn/controller.rb
@@ -51,6 +51,9 @@ module Turn
     # Test framework, either :minitest or :testunit
     attr_accessor :framework
 
+    # Enable full backtrace
+    attr_accessor :trace
+
     def verbose? ; @verbose ; end
     def live?    ; @live    ; end
 
@@ -171,7 +174,7 @@ module Turn
           Turn::CueReporter.new($stdout)
         else
           require 'turn/reporters/outline_reporter'
-          Turn::OutlineReporter.new($stdout)
+          Turn::OutlineReporter.new($stdout, :trace => @trace)
         end
       )
     end

--- a/lib/turn/controller.rb
+++ b/lib/turn/controller.rb
@@ -165,7 +165,7 @@ module Turn
           Turn::ProgressReporter.new($stdout)
         when :dotted
           require 'turn/reporters/dot_reporter'
-          Turn::DotReporter.new($stdout)
+          Turn::DotReporter.new($stdout, :trace => @trace)
         when :pretty
           require 'turn/reporters/pretty_reporter'
           Turn::PrettyReporter.new($stdout)

--- a/lib/turn/reporter.rb
+++ b/lib/turn/reporter.rb
@@ -18,8 +18,9 @@ module Turn
 
     attr :io
 
-    def initialize(io)
+    def initialize(io, opts={})
       @io = io || $stdout
+      @trace = opts[:trace]
     end
 
     # These methods are called in the process of running the tests.

--- a/lib/turn/reporters/dot_reporter.rb
+++ b/lib/turn/reporters/dot_reporter.rb
@@ -55,7 +55,11 @@ module Turn
         list.uniq.each do |testunit|
           message = testunit.fail? ? ' ' + FAIL : ERROR
           message = message + ' ' + testunit.message.tabto(0)
-          message << "\n" + (filter_backtrace(testunit.backtrace).first || '')
+          backtrace = filter_backtrace(testunit.backtrace)
+          message << "\n" + (backtrace.shift || '')
+          if @trace
+            message << "\n" + backtrace.join("\n")
+          end
           report << "\n" << message << "\n"
         end
         report << "\n"

--- a/lib/turn/reporters/outline_reporter.rb
+++ b/lib/turn/reporters/outline_reporter.rb
@@ -60,9 +60,15 @@ module Turn
       io.puts(" #{FAIL}")
       io.puts Colorize.bold(message).tabto(8)
       unless backtrace.empty?
-        backtrace = "Assertion at " + filter_backtrace(assertion.backtrace).first
-        io.puts "STDERR:".tabto(8)
-        io.puts(backtrace.tabto(8))
+        _backtrace = filter_backtrace(assertion.backtrace)
+        _backtrace << "error hogehoge"
+        label = "Assertion at "
+        tabsize = 8
+        backtrace = label + _backtrace.shift
+        io.puts(backtrace.tabto(tabsize))
+        if @trace
+          io.puts _backtrace.map{|l| l.tabto(label.length + tabsize) }.join("\n")
+        end
       end
       show_captured_output
     end

--- a/lib/turn/reporters/outline_reporter.rb
+++ b/lib/turn/reporters/outline_reporter.rb
@@ -61,7 +61,6 @@ module Turn
       io.puts Colorize.bold(message).tabto(8)
       unless backtrace.empty?
         _backtrace = filter_backtrace(assertion.backtrace)
-        _backtrace << "error hogehoge"
         label = "Assertion at "
         tabsize = 8
         backtrace = label + _backtrace.shift

--- a/lib/turn/reporters/pretty_reporter.rb
+++ b/lib/turn/reporters/pretty_reporter.rb
@@ -66,16 +66,19 @@ module Turn
 
       message = assertion.message
 
-      if assertion.respond_to?(:backtrace)
-        trace = filter_backtrace(assertion.backtrace).first
-      else
-        trace = filter_backtrace(assertion.location).first
-      end
-
+      _trace = if assertion.respond_to?(:backtrace)
+                 filter_backtrace(assertion.backtrace)
+               else
+                 filter_backtrace(assertion.location).first
+               end
       io.puts
-      #io.puts pad(message, 10)
-      io.puts message.tabto(10)
-      io.puts trace.tabto(10)
+      tabsize = 10
+      #io.puts pad(message, tabsize)
+      io.puts message.tabto(tabsize)
+      io.puts _trace.shift.tabto(tabsize)
+      if @trace
+        io.puts _trace.map{|l| l.tabto(tabsize) }.join("\n")
+      end
       #show_captured_output
     end
 
@@ -89,15 +92,19 @@ module Turn
 
       message = exception.message
 
-      if exception.respond_to?(:backtrace)
-        trace = filter_backtrace(exception.backtrace).first
-      else
-        trace = filter_backtrace(exception.location).first
-      end
-
+      _trace = if exception.respond_to?(:backtrace)
+                 filter_backtrace(exception.backtrace)
+               else
+                 filter_backtrace(exception.location)
+               end
+      trace = _trace.shift
       io.puts
-      io.puts message.tabto(10)
-      io.puts trace.tabto(10)
+      tabsize = 10
+      io.puts message.tabto(tabsize)
+      io.puts trace.tabto(tabsize)
+      if @trace
+        io.puts _trace.map{|l| l.tabto(tabsize) }.join("\n")
+      end
     end
 
     # TODO: skip support

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,6 +4,7 @@ if RUBY_VERSION < "1.9"
   require 'test/unit'
 else
   require 'minitest/unit'
+  require 'test/unit'
 end
 
 #
@@ -95,3 +96,18 @@ end
   save_test(text, 'minitest_autorun_test.rb')
 end
 
+
+def setup_minitest_autorun_with_fail
+  text = <<-HERE
+require 'minitest/unit'
+require 'rubygems'
+require 'turn'
+MiniTest::Unit.autorun
+class TestTest < MiniTest::Unit::TestCase
+  def test_sample_pass
+    assert_equal(0,1)
+  end
+end
+  HERE
+  save_test(text, 'minitest_autorun_test_with_fail.rb')
+end

--- a/test/test_runners.rb
+++ b/test/test_runners.rb
@@ -39,7 +39,18 @@ class TestRunners < Test::Unit::TestCase
       assert result.index('0 errors')
     end
 
-  end
+    def test_autorun_with_fail
+      file = setup_minitest_autorun_with_fail
+      result = `ruby -Ilib #{file} --trace 2>&1`
+      assert result.index('1 failures')
+      assert result.index('0 errors')
+      assert result.scan(/\.rb:\d+:in/).length > 1
 
+      result = `ruby -Ilib #{file} -t 2>&1`
+      assert result.index('1 failures')
+      assert result.index('0 errors')
+      assert result.scan(/\.rb:\d+:in/).length > 1
+    end
+  end
 end
 


### PR DESCRIPTION
This is the fix for https://github.com/TwP/turn/issues/28

I think it's better to use a wrapper over MiniTest::Unit::TestCase.run() rather than monkey-patch it since other libraries (like Mocha) do this too. This patch fixes the issue so that using Turn with Mocha and Shoulda does not require user to patch Mocha and make sure that they are all required in correct order.
