### PR TITLE
Don't use ANSI codes on dumb terminals in Ruby 1.9

### DIFF
--- a/lib/turn/autorun/minitest.rb
+++ b/lib/turn/autorun/minitest.rb
@@ -1,11 +1,9 @@
 require 'minitest/unit'
 require 'minitest/spec'
 #require 'rubygems'
-require 'ansi'
+require 'turn/colorize'
 
 class MiniTest::Unit
-  include ANSI::Code
-
   PADDING_SIZE = 4
   
   @@use_natural_language_case_names = false
@@ -48,9 +46,9 @@ class MiniTest::Unit
 
     @@out.print "%d tests, " % test_count
     @@out.print "%d assertions, " % assertion_count
-    @@out.print red { "%d failures, " % failures }
-    @@out.print yellow { "%d errors, " % errors }
-    @@out.puts cyan { "%d skips" % skips}
+    @@out.print Turn::Colorize.fail("%d failures, " % failures)
+    @@out.print Turn::Colorize.error("%d errors, " % errors)
+    @@out.puts Turn::Colorize.skip("%d skips" % skips)
 
     return failures + errors if @test_count > 0 # or return nil...
   end
@@ -77,16 +75,16 @@ class MiniTest::Unit
         @@out.print(case inst.run(self)
                     when :pass
                       @broken = false
-                      green { pad_with_size "PASS" }
+                      Turn::Colorize.pass(pad_with_size "PASS")
                     when :error
                       @broken = true
-                      yellow { pad_with_size "ERROR" }
+                      Turn::Colorize.error(pad_with_size "ERROR")
                     when :fail
                       @broken = true
-                      red { pad_with_size "FAIL" }
+                      Turn::Colorize.fail(pad_with_size "FAIL")
                     when :skip
                       @broken = false
-                      cyan { pad_with_size "SKIP" }
+                      Turn::Colorize.skip(pad_with_size "SKIP")
                     end)
 
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -16,6 +16,10 @@ def turn2(*args)
   `ruby -Ilib bin/turn -Ilib #{args.join(' ')}`
 end
 
+def turn_with_term(term, *args)
+  `TERM="#{term}" ruby -Ilib bin/turn -Ilib #{args.join(' ')} 2>&1`
+end
+
 #
 def setup_test(framework, required=false, name=nil)
   text = ''

--- a/test/test_framework.rb
+++ b/test/test_framework.rb
@@ -9,6 +9,13 @@ if RUBY_VERSION >= '1.9'
       setup_test('MiniTest')
       result = turn 'tmp/test.rb'
       assert result.index('PASS')
+      assert result.index('[0m')
+    end
+
+    def test_ruby19_minitest_without_color_on_dumb_terminal
+      setup_test('MiniTest')
+      result = turn_with_term 'dumb', 'tmp/test.rb'
+      assert !result.index('[0m')
     end
 
     def test_ruby19_minitest_force


### PR DESCRIPTION
Now autorun/minitest.rb uses Turn::Colorize for all ANSI manipulations.

Note I Also added an assert that ANSI code _are_ generated in normal Ruby 1.9 tests; this will probably fail if test/runner is run from a background process (without the TERM env var).
