### PR TITLE
Use class variable @@use_natural_language_case_names

### DIFF
--- a/lib/turn/autorun/minitest.rb
+++ b/lib/turn/autorun/minitest.rb
@@ -8,11 +8,11 @@ class MiniTest::Unit
   
   @@use_natural_language_case_names = false
   def self.use_natural_language_case_names=(boolean)
-    @use_natural_language_case_names = boolean
+    @@use_natural_language_case_names = boolean
   end
   
   def self.use_natural_language_case_names?
-    @use_natural_language_case_names
+    @@use_natural_language_case_names
   end
   
 


### PR DESCRIPTION
This removes the crazy warnings generated when running tests on 1.9.2
with warnings enabled.
