### PR TITLE
Remove a warning about instance variable @use_natural_language_case_names

### DIFF
--- a/lib/turn/autorun/minitest.rb
+++ b/lib/turn/autorun/minitest.rb
@@ -12,7 +12,7 @@ class MiniTest::Unit
   end
   
   def self.use_natural_language_case_names?
-    @use_natural_language_case_names
+    @use_natural_language_case_names ||= false
   end
   
 


### PR DESCRIPTION
Remove a warning about instance variable @use_natural_language_case_names being not initialized when running with $-w set to true.
