### PR TITLE
Don't show colors if stdout is not a tty

### DIFF
--- a/lib/turn/autorun/testunit0.rb
+++ b/lib/turn/autorun/testunit0.rb
@@ -34,7 +34,7 @@ module Console
       pass = total - failure - error
 
       bar = '=' * 78
-      if COLORIZE
+      if colorize?
         bar = if pass == total then ::ANSI::Code.green{bar}
               else ::ANSI::Code.red{bar} end
       end
@@ -49,7 +49,7 @@ module Console
       method, file = name.scan(%r/^([^\(]+)\(([^\)]+)\)/o).flatten!
       if @t_cur_file != file
         @t_cur_file = file
-        file = COLORIZE ? ::ANSI::Code.yellow{file} : file
+        file = colorize? ? ::ANSI::Code.yellow{file} : file
         turn_out.puts file
       end
       turn_out.print "    %-69s" % method
@@ -76,7 +76,7 @@ module Console
         msg << fault.message.gsub("\n","\n\t")
       end
 
-      msg = ::ANSI::Code.magenta{msg} if COLORIZE
+      msg = ::ANSI::Code.magenta{msg} if colorize?
       turn_out.puts msg
     end
 

--- a/lib/turn/colorize.rb
+++ b/lib/turn/colorize.rb
@@ -12,47 +12,54 @@ module Turn
 
   module Colorize
 
-    COLORLESS_TERMINALS = ['dumb']	
-    COLORIZE = defined?(::ANSI::Code) && ENV.has_key?('TERM') && !COLORLESS_TERMINALS.include?(ENV['TERM']) && $stdout.tty?
+    COLORLESS_TERMINALS = ['dumb']
+
+    def colorize?
+      defined?(::ANSI::Code) &&
+        ENV.has_key?('TERM') &&
+        !COLORLESS_TERMINALS.include?(ENV['TERM']) &&
+        $stdout.tty?
+    end
+    module_function :colorize?
 
     def self.red(string)
-      COLORIZE ? ::ANSI::Code.red{ string } : string
+      colorize? ? ::ANSI::Code.red{ string } : string
     end
 
     def self.green(string)
-      COLORIZE ? ::ANSI::Code.green{ string } : string
+      colorize? ? ::ANSI::Code.green{ string } : string
     end
 
     def self.blue(string)
-      COLORIZE ? ::ANSI::Code.blue{ string } : string
+      colorize? ? ::ANSI::Code.blue{ string } : string
     end
 
     def self.magenta(string)
-      COLORIZE ? ::ANSI::Code.magenta{ string } : string
+      colorize? ? ::ANSI::Code.magenta{ string } : string
     end
 
     def self.bold(string)
-      COLORIZE ? ::ANSI::Code.bold{ string } : string
+      colorize? ? ::ANSI::Code.bold{ string } : string
     end
 
     def self.pass(string)
-      COLORIZE ? ::ANSI::Code.green{ string } : string
+      colorize? ? ::ANSI::Code.green{ string } : string
     end
 
     def self.fail(string)
-      COLORIZE ? ::ANSI::Code.red{ string } : string
+      colorize? ? ::ANSI::Code.red{ string } : string
     end
 
     #def self.error(string)
-    #  COLORIZE ? ::ANSI::Code.white{ ::ANSI::Code.on_red{ string } } : string
+    #  colorize? ? ::ANSI::Code.white{ ::ANSI::Code.on_red{ string } } : string
     #end
 
     def self.error(string)
-      COLORIZE ? ::ANSI::Code.yellow{ string } : string
+      colorize? ? ::ANSI::Code.yellow{ string } : string
     end
 
     def self.skip(string)
-      COLORIZE ? ::ANSI::Code.cyan{ string } : string
+      colorize? ? ::ANSI::Code.cyan{ string } : string
     end
 
     PASS  = pass('PASS')

--- a/lib/turn/colorize.rb
+++ b/lib/turn/colorize.rb
@@ -13,7 +13,7 @@ module Turn
   module Colorize
 
     COLORLESS_TERMINALS = ['dumb']	
-    COLORIZE = defined?(::ANSI::Code) && ENV.has_key?('TERM') && !COLORLESS_TERMINALS.include?(ENV['TERM'])
+    COLORIZE = defined?(::ANSI::Code) && ENV.has_key?('TERM') && !COLORLESS_TERMINALS.include?(ENV['TERM']) && $stdout.tty?
 
     def self.red(string)
       COLORIZE ? ::ANSI::Code.red{ string } : string

--- a/lib/turn/reporters/cue_reporter.rb
+++ b/lib/turn/reporters/cue_reporter.rb
@@ -105,7 +105,7 @@ module Turn
       pass    = total - failure - error
 
       bar = '=' * 78
-      if COLORIZE
+      if colorize?
         bar = if pass == total then Colorize.green(bar)
               else Colorize.red(bar) end
       end

--- a/lib/turn/reporters/outline_reporter.rb
+++ b/lib/turn/reporters/outline_reporter.rb
@@ -137,7 +137,7 @@ module Turn
       pass    = total - failure - error
 
       bar = '=' * 78
-      if COLORIZE
+      if colorize?
         bar = if pass == total then Colorize.green(bar)
               else Colorize.red(bar) end
       end

--- a/test/test_framework.rb
+++ b/test/test_framework.rb
@@ -9,13 +9,27 @@ if RUBY_VERSION >= '1.9'
       setup_test('MiniTest')
       result = turn 'tmp/test.rb'
       assert result.index('PASS')
-      assert result.index('[0m') if $ansi
     end
 
-    def test_ruby19_minitest_without_color_on_dumb_terminal
-      setup_test('MiniTest')
-      result = turn_with_term 'dumb', 'tmp/test.rb'
-      assert !result.index('[0m')
+    def test_ruby19_minitest_color
+      term, stdout = ENV['TERM'], $stdout
+      $stdout = $stdout.dup
+      def $stdout.tty?
+        true
+      end
+      ENV['TERM'] = 'xterm'
+      assert_equal true, Turn::Colorize.colorize?
+      ENV['TERM'] = 'dumb'
+      assert_equal false, Turn::Colorize.colorize?
+      ENV['TERM'] = nil
+      assert_equal false, Turn::Colorize.colorize?
+      ENV['TERM'] = 'xterm'
+      def $stdout.tty?
+        false
+      end
+      assert_equal false, Turn::Colorize.colorize?
+    ensure
+      ENV['TERM'], $stdout = term, stdout
     end
 
     def test_ruby19_minitest_force

--- a/work/turn.rb
+++ b/work/turn.rb
@@ -67,14 +67,14 @@ module Console
       when ::Test::Unit::Error
         msg = "\t"
         msg << fault.to_s.split("\n")[2..-1].join("\n\t")
-        msg = ::ANSI::Code.magenta(msg) if COLORIZE
+        msg = ::ANSI::Code.magenta(msg) if colorize?
         @t_test.error!(msg)
         @t_reporter.error(msg)
       when ::Test::Unit::Failure
         msg = "\t"
         msg << fault.location[0] << "\n\t"
         msg << fault.message.gsub("\n","\n\t")
-        msg = ::ANSI::Code.magenta(msg) if COLORIZE
+        msg = ::ANSI::Code.magenta(msg) if colorize?
         @t_test.fail!(msg)
         @t_reporter.fail(msg)
       end


### PR DESCRIPTION
This prevents raw color codes popping up if the output of turn is piped to a pager or redirected to a file, and is generally considered to be a best practice for command line tools. It also prevents them from showing up if turn is invoked inside ruby backticks, which has the unfortunate side effect of breaking the tests that looks for colors. I'm open to suggestions of how to fix this.
