### PR TITLE
Added `lib/turn/autoload` to Bones config, so it's not missing from .gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ Bones {
   ignore_file  '.gitignore'
 
   exclude      << '^work'
+  include      << 'lib/turn/autoload'
   rdoc.exclude << '^lib'
 
   use_gmail


### PR DESCRIPTION
Hi,

this fixes an error where running a test suite fails with "file not found -- lib/turn/autoload" on Ruby 1.9.3.

Not sure why it's not added by default, but it's definitely missing from the generated gemspec.
