### PR TITLE
colored output on Windows

### DIFF
--- a/lib/turn/colorize.rb
+++ b/lib/turn/colorize.rb
@@ -15,9 +15,15 @@ module Turn
     COLORLESS_TERMINALS = ['dumb']
 
     def colorize?
-      defined?(::ANSI::Code) &&
-        ENV.has_key?('TERM') &&
-        !COLORLESS_TERMINALS.include?(ENV['TERM']) &&
+      defined?(::ANSI::Code) && (
+        (
+          ENV.has_key?('TERM') &&
+            !COLORLESS_TERMINALS.include?(ENV['TERM'])
+        ) || (
+          ::RbConfig::CONFIG['host_os'] =~ /mswin|mingw/ &&
+            ENV.has_key?('ANSICON')
+        )
+      ) &&
         $stdout.tty?
     end
     module_function :colorize?

--- a/test/test_framework.rb
+++ b/test/test_framework.rb
@@ -13,16 +13,25 @@ if RUBY_VERSION >= '1.9'
 
     def test_ruby19_minitest_color
       term, stdout = ENV['TERM'], $stdout
+      host_os, ansicon, = ::RbConfig::CONFIG['host_os'], ENV['ANSICON']
       $stdout = $stdout.dup
       def $stdout.tty?
         true
       end
+      ENV['ANSICON'] = nil
       ENV['TERM'] = 'xterm'
       assert_equal true, Turn::Colorize.colorize?
       ENV['TERM'] = 'dumb'
       assert_equal false, Turn::Colorize.colorize?
       ENV['TERM'] = nil
       assert_equal false, Turn::Colorize.colorize?
+      ['mingw32', 'mswin32'].each do |os|
+        ::RbConfig::CONFIG['host_os'] = os
+        ENV['ANSICON'] = '120x5000 (120x50)'
+        assert_equal true, Turn::Colorize.colorize?
+        ENV['ANSICON'] = nil
+        assert_equal false, Turn::Colorize.colorize?
+      end
       ENV['TERM'] = 'xterm'
       def $stdout.tty?
         false
@@ -30,6 +39,7 @@ if RUBY_VERSION >= '1.9'
       assert_equal false, Turn::Colorize.colorize?
     ensure
       ENV['TERM'], $stdout = term, stdout
+      ::RbConfig::CONFIG['host_os'], ENV['ANSICON'] = host_os, ansicon
     end
 
     def test_ruby19_minitest_force


### PR DESCRIPTION
I am using same method as they do in rspec: https://github.com/rspec/rspec-core/blob/de2906829d8f189c1be10e2a8210d882a0b4493f/lib/rspec/core/configuration.rb#L394

simmilar is used in cucumber as well: https://github.com/cucumber/cucumber/blob/bc2e7526711903dd452881b8087b74a9395aae17/lib/cucumber/formatter/ansicolor.rb#L17

tests provided

I hope it will be released soon in gem. ;-)
