### PR TITLE
Fixes minirunner support to pending/skip test cases

### DIFF
--- a/lib/turn/reporters/outline_reporter.rb
+++ b/lib/turn/reporters/outline_reporter.rb
@@ -100,6 +100,14 @@ module Turn
     end
 
     #
+    def skip(exception)
+      message   = exception.message      
+      io.puts(" #{SKIP}")
+      io.puts(message.tabto(8))
+      show_captured_output
+    end
+
+    #
     def finish_test(test)
       $stdout = STDOUT
       $stderr = STDERR

--- a/lib/turn/runners/minirunner.rb
+++ b/lib/turn/runners/minirunner.rb
@@ -101,8 +101,8 @@ module Turn
     def puke(klass, meth, err)
       case err
       when MiniTest::Skip
-        @turn_test.skip!
-        turn_reporter.skip #(e)
+        @turn_test.skip!(err)
+        turn_reporter.skip(err)
       when MiniTest::Assertion
         @turn_test.fail!(err)
         turn_reporter.fail(err)


### PR DESCRIPTION
Tested on
- ruby 1.9.3p0 (2011-10-30 revision 33570) [x86_64-darwin11.2.0]
- rails (3.1.3)

No tests included
