### PR TITLE
Make files ending with _test show up, even if they are in the test/units folder

### DIFF
--- a/lib/turn/reporter.rb
+++ b/lib/turn/reporter.rb
@@ -77,7 +77,7 @@ module Turn
       /\/lib\/turn.*\.rb/,
       /\/bin\/turn/,
       /\/lib\/minitest.*\.rb/,
-      /\/test\/unit.*\.rb/
+      /\/test\/unit\/(?!.*\_test.rb).*\.rb.*/
     ])
 
     # Filter backtrace of unimportant entries, and applies count limit if set in

--- a/lib/turn/reporter.rb
+++ b/lib/turn/reporter.rb
@@ -77,7 +77,7 @@ module Turn
       /\/lib\/turn.*\.rb/,
       /\/bin\/turn/,
       /\/lib\/minitest.*\.rb/,
-      /\/test\/unit\/(?!.*\_test.rb).*\.rb.*/
+      /\/test\/unit(?!(\/.*\_test.rb)|.*\/test_.*).*\.rb.*/
     ])
 
     # Filter backtrace of unimportant entries, and applies count limit if set in

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -1,0 +1,20 @@
+require File.expand_path(File.dirname(__FILE__)) + '/helper.rb'
+require File.expand_path(File.dirname(__FILE__) + '/..') + '/lib/turn/reporter'
+
+class TestReporter < Turn::Reporter
+end
+
+class TestReporters < Test::Unit::TestCase
+  def test_unit_test_files_are_filtered_but_project_files_are_not
+    reporter = TestReporter.new(nil)
+    
+    # If you follow the convention of naming your test files with _test.rb, do not filter that
+    # test file from the stack trace
+    filtered_lines = ["/Users/testman/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/test/unit/assertions.rb:185:in `assert_equal'"]
+    unfiltered_lines = ["/Users/testman/source/campaign_manager/test/unit/omg_test.rb:145:in `block in <class:OmgTest>'", 
+      "/Users/testman/source/campaign_manager/app/models/omg.rb:145:in `in double_rainbows'" ]
+    stack_trace = filtered_lines + unfiltered_lines
+
+    assert_equal unfiltered_lines, reporter.send(:filter_backtrace, stack_trace)
+  end
+end

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -5,7 +5,7 @@ class TestReporter < Turn::Reporter
 end
 
 class TestReporters < Test::Unit::TestCase
-  def test_unit_test_files_are_filtered_but_project_files_are_not
+  def test_unit_test_files_are_not_filtered_out_if_ending_in_test
     reporter = TestReporter.new(nil)
     
     # If you follow the convention of naming your test files with _test.rb, do not filter that
@@ -17,4 +17,19 @@ class TestReporters < Test::Unit::TestCase
 
     assert_equal unfiltered_lines, reporter.send(:filter_backtrace, stack_trace)
   end
+
+  def test_unit_test_files_are_not_filtered_out_if_file_name_starts_with_test_underscore
+    reporter = TestReporter.new(nil)
+    
+    # If you follow the convention of naming your test files with _test.rb, do not filter that
+    # test file from the stack trace
+    filtered_lines = ["/Users/testman/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/test/unit/assertions.rb:185:in `assert_equal'"]
+    unfiltered_lines = ["/Users/testman/source/campaign_manager/test/unit/test_omgs.rb:145:in `block in <class:OmgTest>'", 
+      "/Users/testman/source/campaign_manager/app/models/omg.rb:145:in `in double_rainbows'" ]
+    stack_trace = filtered_lines + unfiltered_lines
+
+    assert_equal unfiltered_lines, reporter.send(:filter_backtrace, stack_trace)
+  end
+
+
 end


### PR DESCRIPTION
Before the line of the test that was failing was being filtered out from the stacktrace if the test mode was unit.  This was causing a stacktrace that was this:

```
/Users/testman/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/test/unit/assertions.rb:185:in `assert_equal'
/Users/testman/source/campaign_manager/test/unit/omg_test.rb:145:in `block in <class:OmgTest>
/Users/testman/source/campaign_manager/app/models/omg.rb:145:in `in double_rainbows`
```

to be filtered to this:

```
/Users/testman/source/campaign_manager/app/models/omg.rb:145:in `in double_rainbows`
```

and not give what line of the test file the assertion or exception failed at.  This was caused by the filter_backtrace method removing all the elements of the backtrace that are in the test/units directory (and not only the ones that were specific for rails infrastructure test directory like assertion.rb).

This change does the following:
- Adjust the regex, so if the user follows the rails convention of naming their test file ending with _test.rb, that part of the backtrace will not be filtered out.
- Add a unit test for this case.  The current tests seemed to all shell out to call the executable directly.  Since the test I wanted to add was at the level of the Reporter class, I made a new test file for this, because it didn't seem to belong with the other tests.

Let me know if there are any changes that I need to make before getting this merged into master.
