### PR TITLE
Passed test - dot, skipped - s

### DIFF
--- a/lib/turn/reporters/dot_reporter.rb
+++ b/lib/turn/reporters/dot_reporter.rb
@@ -19,7 +19,7 @@ module Turn
     end
 
     def pass(message=nil)
-      io.print Colorize.pass('S'); io.flush
+      io.print Colorize.pass('.'); io.flush
     end
 
     def fail(assertion, message=nil)
@@ -31,7 +31,7 @@ module Turn
     end
 
     def skip(exception, message=nil)
-      io.print Colorize.skip('-'); io.flush
+      io.print Colorize.skip('S'); io.flush
     end
 
     def finish_test(test)


### PR DESCRIPTION
When I used turn first time, I'd automaticly picked "dot" formater and after running tests for the first time I was a bit confused becouse I saw line with bunch of green `S` and thought that sth was broken and all of them were skipped. Messaged at the end, that X test passed make it clear, but still I think it would be good to change this.

I think it's a bit confusing for dot reporter to have `S` char for test that passed. It was always `.` and since MiniTest is included in 1.9.x and it marks skipped test as `S`, turn's conventions makes it even more confusing for people that used to use TestUnit/MiniTest default formatters.

This simple commit changes:

`S` to `.` for succesful ones
`-` to `S` for skipped ones
