### PR TITLE
Backtrace filtering out project files

### DIFF
--- a/lib/turn/reporter.rb
+++ b/lib/turn/reporter.rb
@@ -87,7 +87,8 @@ module Turn
     def filter_backtrace(backtrace)
       return [] unless backtrace
       bt = backtrace.dup
-      bt = bt.reject{ |line| $RUBY_IGNORE_CALLERS.any?{ |re| re =~ line } } unless $DEBUG
+      pwd= Dir.pwd
+      bt = bt.reject{ |line| $RUBY_IGNORE_CALLERS.any?{|re| re =~ line} unless line.start_with?(pwd) } unless $DEBUG
       #bt.reject!{ |line| line.rindex('minitest') }
       #bt.reject!{ |line| line.rindex('test/unit') }
       #bt.reject!{ |line| line.rindex('lib/turn') }


### PR DESCRIPTION
Hi. I have tests such as test/unit/blah_test.rb
Backtrace filters were filtering out everything with test/unit in it.

I've modified it so if the file is in a subdir of the current/project directory, then it stays (i.e. is not filtered out anymore).
All other filtering rules are unchanged.
