### PR TITLE
Color the bars green when all tests pass in outline format - TwP/turn#81

### DIFF
--- a/lib/turn/reporters/outline_reporter.rb
+++ b/lib/turn/reporters/outline_reporter.rb
@@ -165,11 +165,7 @@ module Turn
       skips      = suite.count_skips
 
       bar = '=' * 78
-      # @FIXME: Remove this, since Colorize already take care of colorize?
-      if colorize?
-        bar = if pass == total then Colorize.green(bar)
-              else Colorize.red(bar) end
-      end
+      bar = passes == total ? Colorize.green(bar) : Colorize.red(bar)
 
       # @FIXME: Should we add suite.runtime, instead if this lame time calculations?
       tally = [total, assertions, (Time.new - @time)]


### PR DESCRIPTION
The real issue was just that the variable name that contained the number of passed tests is `passes` and the line was using `pass`.

I saw the FIXME note, "Remove this, since Colorize already take care of colorize?". I looked into it and `Colorize.green` and `Colorize.red` both check `colorize?` first and return the bare string if it's false. So, I fixed that too.
