### PR TITLE
Add support for natural test names in pretty format

### DIFF
--- a/lib/turn/reporter.rb
+++ b/lib/turn/reporter.rb
@@ -108,9 +108,9 @@ module Turn
     #
     def naturalized_name(test)
       if @natural
-        " #{test.name.gsub("test_", "").gsub(/_/, " ")}"
+        test.name.gsub("test_", "").gsub(/_/, " ")
       else
-        " #{test.name}"
+        test.name
       end
     end
 

--- a/lib/turn/reporter.rb
+++ b/lib/turn/reporter.rb
@@ -105,7 +105,7 @@ module Turn
       @trace ? backtrace[0, @trace.to_i] : backtrace
     end
 
-    #
+    # Returns a more readable test name with spaces instead of underscores
     def naturalized_name(test)
       if @natural
         test.name.gsub("test_", "").gsub(/_/, " ")

--- a/lib/turn/reporters/cue_reporter.rb
+++ b/lib/turn/reporters/cue_reporter.rb
@@ -27,7 +27,8 @@ module Turn
       #  @file = test.file
       #  io.puts(test.file)
       #end
-      io.print Colorize.blue("    %-69s" % test.name)
+      name = naturalized_name(test)
+      io.print Colorize.blue("    %-69s" % name)
       $stdout = @stdout
       $stderr = @stderr
       $stdout.rewind

--- a/lib/turn/reporters/outline_reporter.rb
+++ b/lib/turn/reporters/outline_reporter.rb
@@ -49,7 +49,7 @@ module Turn
       # @FIXME: Should we move naturalized_name to test itself?
       name = naturalized_name(test)
 
-      io.print "    %-57s" % name
+      io.print "     %-57s" % name
 
       @stdout.rewind
       @stderr.rewind

--- a/lib/turn/reporters/pretty_reporter.rb
+++ b/lib/turn/reporters/pretty_reporter.rb
@@ -122,7 +122,8 @@ module Turn
     # Example:
     #    PASS test: Test decription.  (0:00:02:059)
     def banner(event)
-      io.puts "%18s %s (%s)" % [event, @test, ticktock]
+      name = naturalized_name(@test)
+      io.puts "%18s %s (%s)" % [event, name, ticktock]
     end
 
     # Cleanups and prints test payload


### PR DESCRIPTION
Adding to dhh's pull request about a year ago (TwP/turn#30), this pull request adds support for natural names _in the pretty format_.

When `natural = false` (default) nothing changes.  When `natural = true`, the test name appears with spaces instead of underscores the way Rails users are encouraged to write tests.
