### PR TITLE
Fix test rake task on Windows

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
-task :default => 'test'
+task :default => :test
 
 desc "Run unit tests"
 task :test do
-  sh 'test/runner'
+  ruby "-Ilib bin/turn -Ilib test/*.rb"
 end
 
 desc "build gem package"


### PR DESCRIPTION
Windows doesn't support running files with a shebang. So, I changed the rake test task to do the same thing as test/runner using rake's `ruby` method.
