### PR TITLE
Issue #96: MiniRunner should not change @@out, but override output() instead

### DIFF
--- a/lib/turn/runners/minirunner.rb
+++ b/lib/turn/runners/minirunner.rb
@@ -17,9 +17,13 @@ module Turn
 
       super()
 
-      # route minitests traditional output to nowhere
-      # (instead of overriding #puts and #print)
-      @@out = ::StringIO.new
+      # a stream we will use to route minitests traditional output
+      @out = ::StringIO.new
+    end
+
+    # route minitests traditional output to nowhere
+    def output
+      @out
     end
 
     #


### PR DESCRIPTION
fix for issue #96.
MiniRunner doesn't change @@out, but override output() to return dummy stream to catch all traditional minitest output.
