### PR TITLE
Small time format fix

### DIFF
--- a/lib/turn/reporter.rb
+++ b/lib/turn/reporter.rb
@@ -119,7 +119,7 @@ module Turn
     #
     def ticktock
       t = Time.now - @time
-      h, t = t.divmod(360)
+      h, t = t.divmod(3600)
       m, t = t.divmod(60)
       s = t.truncate
       f = ((t - s) * 1000).to_i

--- a/lib/turn/reporter.rb
+++ b/lib/turn/reporter.rb
@@ -119,7 +119,7 @@ module Turn
     #
     def ticktock
       t = Time.now - @time
-      h, t = t.divmod(60)
+      h, t = t.divmod(360)
       m, t = t.divmod(60)
       s = t.truncate
       f = ((t - s) * 1000).to_i


### PR DESCRIPTION
Hi. Thanks for great work on turn. I noticed the time format in the output seems to put minutes in the hours slot, which leaves the minutes as "00" all the time (example: 2:00:41.408 should be 0:02:41.408). My change addresses that. Thanks.

Fixed output where minutes appeared in the hours slot, leaving minutes to be zero all the time.
