### PR TITLE
Allow users to specify their own reporters.

### DIFF
--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -1,3 +1,6 @@
+$: << File.expand_path("./.turnreporters")
+$: << File.expand_path("~/.turnreporters")
+
 module Turn
 end
 

--- a/lib/turn/configuration.rb
+++ b/lib/turn/configuration.rb
@@ -182,24 +182,12 @@ module Turn
       @reporter ||= (
         opts = reporter_options
         case format
-        when :marshal
-          require 'turn/reporters/marshal_reporter'
-          Turn::MarshalReporter.new($stdout, opts)
-        when :progress
-          require 'turn/reporters/progress_reporter'
-          Turn::ProgressReporter.new($stdout, opts)
-        when :dotted, :dot
+        when :marshal, :progress, :dot, :outline, :cue, :pretty
+          require "turn/reporters/#{format.to_s}_reporter"
+          Turn.const_get(format.to_s.capitalize + "Reporter").send(:new, $stdout, opts)
+        when :dotted
           require 'turn/reporters/dot_reporter'
           Turn::DotReporter.new($stdout, opts)
-        when :outline
-          require 'turn/reporters/outline_reporter'
-          Turn::OutlineReporter.new($stdout, opts)
-        when :cue
-          require 'turn/reporters/cue_reporter'
-          Turn::CueReporter.new($stdout, opts)
-        when :pretty
-          require 'turn/reporters/pretty_reporter'
-          Turn::PrettyReporter.new($stdout, opts)
         else
           require 'turn/reporters/pretty_reporter'
           Turn::PrettyReporter.new($stdout, opts)

--- a/lib/turn/configuration.rb
+++ b/lib/turn/configuration.rb
@@ -181,17 +181,14 @@ module Turn
     def reporter
       @reporter ||= (
         opts = reporter_options
-        case format
-        when :marshal, :progress, :dot, :outline, :cue, :pretty
-          require "turn/reporters/#{format.to_s}_reporter"
-          Turn.const_get(format.to_s.capitalize + "Reporter").send(:new, $stdout, opts)
-        when :dotted
-          require 'turn/reporters/dot_reporter'
-          Turn::DotReporter.new($stdout, opts)
-        else
-          require 'turn/reporters/pretty_reporter'
-          Turn::PrettyReporter.new($stdout, opts)
+        rpt_format = (format == :dotted ? :dot : format)
+
+        begin
+          require "#{rpt_format.to_s}_reporter"
+        rescue LoadError
+          require "turn/reporters/#{rpt_format.to_s}_reporter"
         end
+        Turn.const_get(rpt_format.to_s.capitalize + "Reporter").send(:new, $stdout, opts)
       )
     end
 
@@ -202,7 +199,7 @@ module Turn
 
     #
     def environment_format
-      ENV['rpt']
+      ENV['rpt'] || :pretty
     end
 
     #


### PR DESCRIPTION
This would allow for any user to write their own Reporter, and stick it in their project's .turnreporters directory, or in their home directory's .turnreporters dir.

Search order is:

{project}/.turnreporters/
~/.turnreporters/
turn/reporters/

Perhaps ironic that there are no tests. I'm actually a pretty novice tester (working on that). I don't know how to set up tests for require's. I'm happy to give it a try if someone can help point me to how to do that.

Cheers,
Ryan
