### PR TITLE
Minimal test case for issue #111. Illustrates that autorun plus test nam...

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -118,6 +118,24 @@ end
   save_test(text, 'outline_test.rb')
 end
 
+def setup_minispec
+  text = <<-HERE
+require 'turn'
+require 'minitest/autorun'
+
+describe 'multiple tests' do
+  it 'should pass' do
+    assert true
+  end
+
+  it 'should fail' do
+    assert false
+  end
+end
+  HERE
+  save_test(text, 'minispec_test.rb')
+end
+
 #
 def setup_minitest_autorun
   text = <<-HERE

--- a/test/test_runners.rb
+++ b/test/test_runners.rb
@@ -18,6 +18,15 @@ class TestRunners < Test::Unit::TestCase
     assert result.index('0 errors'), "ACTUAL RESULT:\n #{result}"
   end
 
+  def test_minispec_name
+    file = setup_minispec
+    result = turn2 '-n "/fail/"', file
+
+    assert result.index('0 passed'), "ACTUAL RESULT:\n #{result}"
+    assert result.index('1 failures'), "ACTUAL RESULT:\n #{result}"
+    assert result.index('1 assertions'),  "ACTUAL RESULT:\n #{result}"
+  end
+
   # autorun
 
   #if RUBY_VERSION < '1.9'
@@ -30,6 +39,15 @@ class TestRunners < Test::Unit::TestCase
       assert(result.index('0 errors'), "ACTUAL RESULT:\n #{result}")
     end
 
+    def test_autorun_minispec_name
+      file = setup_minispec
+      result = `ruby -Ilib #{file} -n "/fail/" 2>&1`
+
+      assert result.index('0 passed'), "ACTUAL RESULT:\n #{result}"
+      assert result.index('1 failures'), "ACTUAL RESULT:\n #{result}"
+      assert result.index('1 assertions'),  "ACTUAL RESULT:\n #{result}"
+    end
+
   #else
 
     def test_autorun
@@ -38,6 +56,15 @@ class TestRunners < Test::Unit::TestCase
       assert result.index('0 failures'),  "ACTUAL RESULT:\n #{result}"
       assert result.index('0 errors'), "ACTUAL RESULT:\n #{result}"
     end
+
+    def test_autorun_minitest_name
+      file = setup_minitest_autorun
+      result = `ruby -Ilib #{file} -n "/sample/" 2>&1`
+
+      assert result.index('1 passed'), "ACTUAL RESULT:\n #{result}"
+      assert result.index('1 assertions'),  "ACTUAL RESULT:\n #{result}"
+    end
+
 
     def test_autorun_with_trace
       file = setup_minitest_autorun_with_trace


### PR DESCRIPTION
...e filtering is not working.

Also adds a test that shows using /bin/turn and name filtering DOES work.

The failing tests show that the autorun and name filtering does not work independent of whether your tests are minitest style or minispec style.

I started trying to fix this but wasn't having much luck finding my way around the code, so I decided submitting this test case was better than nothing :(
