### PR TITLE
Fixed minitest dependency.

### DIFF
--- a/lib/turn/minitest.rb
+++ b/lib/turn/minitest.rb
@@ -1,6 +1,6 @@
 # make sure latest verison is used, rather than ruby's built-in
 begin
-  gem 'minitest'
+  gem 'minitest', '~> 4.7.5'
 rescue Exception
   warn "gem install minitest"
 end
@@ -20,7 +20,7 @@ if MiniTest::Unit.respond_to?(:runner=)
   MiniTest::Unit.runner = Turn::MiniRunner.new
 else
   raise "MiniTest v#{MiniTest::Unit::VERSION} is out of date.\n" \
-        "Please update to a newer version."
+        "Please update to a newer version, but version 5.0.0 or above will not work. ."
   #MiniTest::Unit = Turn::MiniRunner
 end
 

--- a/lib/turn/minitest.rb
+++ b/lib/turn/minitest.rb
@@ -1,6 +1,6 @@
 # make sure latest verison is used, rather than ruby's built-in
 begin
-  gem 'minitest', '~> 4.7.5'
+  gem 'minitest', '< 5.0.0'
 rescue Exception
   warn "gem install minitest"
 end


### PR DESCRIPTION
Fixed the error message to let the user know Minitest 5 breaks Turn. Also added a version number for minitest, to prevent this error from ever showing up. Minitest 5 is not compatible with Turn. This is a bigger issue to fix, but this will at least keep turn working. 
