### PR TITLE
Add tags option for only running tagged tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg
 tmp
 /tags
 .ruby-version
+*.sublime*

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Options are following:
     exclude         List of file names or globs to exclude from tests list. Default: []
     pattern         Regexp pattern that all test names must match to be eligible to run. Default: /.*/ (all)
     matchcase       Regexp pattern that all test cases must match to be eligible to run. Default: nil (all)
+    tags            If specified, test cases must have at least one of these tags to be eligible to run. 
+                    Requires minitest-metadata for tagging. Tags are colon-separated. Default: [] (all)
     loadpath        Add these folders to the $LOAD_PATH. Default: ['lib']
     requires        Libs to require when running tests. Default: []
     format          Reporter type (:pretty, :dot, :cue, :marshal, :outline, :progress). Default: :pretty

--- a/lib/turn/command.rb
+++ b/lib/turn/command.rb
@@ -55,6 +55,9 @@ module Turn
     # Only run testcases matching this pattern.
     attr :matchcase
 
+    # if minitest-metadata is installed, only run testcases which have at least one of these tags
+    attr :tags
+
     # List of paths to add to $LOAD_PATH
     attr :loadpath
 
@@ -91,6 +94,7 @@ module Turn
       @log       = nil
       @pattern   = nil
       @matchcase = nil
+      @tags      = []
       @loadpath  = []
       @requires  = []
       @runmode   = nil
@@ -138,6 +142,10 @@ module Turn
           else
             @matchcase = Regexp.new(pattern, Regexp::IGNORECASE)
           end
+        end
+
+        opts.on('-t', '--tags=TAGS', "only run test cases with at least one TAG (colon-separated, requires minitest-metadata)") do |tags|
+          @tags = tags.split(':').collect { |tag| tag.to_sym }
         end
 
         opts.on('-m', '--mark=SECONDS', "Mark test if it exceeds runtime threshold.") do |int|
@@ -264,6 +272,7 @@ module Turn
         c.mode      = decmode
         c.pattern   = pattern
         c.matchcase = matchcase
+        c.tags      = tags
         c.trace     = trace
         c.natural   = natural
         c.verbose   = verbose

--- a/lib/turn/configuration.rb
+++ b/lib/turn/configuration.rb
@@ -27,6 +27,9 @@ module Turn
     # match to be eligible to run.
     attr_accessor :matchcase
 
+    # all tests must have at least one of these tags to be eligible to run
+    attr_accessor :tags
+
     # Add these folders to the $LOAD_PATH.
     attr_reader :loadpath
 
@@ -98,6 +101,7 @@ module Turn
       @live      ||= false
       @log       ||= true
       @matchcase ||= nil
+      @tags      ||= []
       @pattern   ||= /.*/
       @natural   ||= false
       @verbose   ||= false


### PR DESCRIPTION
Hi,

Not sure if there would be general interest in this feature or not, but we needed it.

This PR adds a `tags` option which limits the tests run to those which are tagged with at least one of the specified tags. It relies on https://github.com/wojtekmach/minitest-metadata to provide the tagging metadata, but if that gem is not installed, everything should still work (minus the tags option, obviously).

Additionally, if the user employs the long form of metadata with a non-truthy value (e.g. `quick: false`), this effectively turns off the tag. When the short form is used (e.g. `:quick`), `minitest-metadata` automatically fills in the value with `true`, so it works as you would expect.

It was not clear to me how such a feature should be unit tested, so I don't have any tests in this PR. I did, however, test it manually with our turn-based tests, and it worked as expected. Let me know if there's tests I should add somewhere.

Suggestions for improvements are welcome!

cc/ @jasonrwagner and @ring0lab
