### PR TITLE
Report failed test name in dot format output

### DIFF
--- a/lib/turn/reporters/dot_reporter.rb
+++ b/lib/turn/reporters/dot_reporter.rb
@@ -57,8 +57,11 @@ module Turn
       unless list.empty? # or verbose?
         #report << "\n\n-- Failures and Errors --\n\n"
         list.uniq.each do |testunit|
+          heading = []
           message = []
-          message << (testunit.fail? ? FAIL : ERROR)
+          heading << (testunit.fail? ? FAIL : ERROR)
+          heading << testunit.name
+          message << heading.join(' ')
           message << testunit.message.tabto(2)
           message << clean_backtrace(testunit.backtrace).join("\n").tabto(2)
           report << "\n" << message.join("\n") << "\n"

--- a/lib/turn/reporters/dot_reporter.rb
+++ b/lib/turn/reporters/dot_reporter.rb
@@ -49,18 +49,18 @@ module Turn
       suite.each do |testcase|
         testcase.each do |testunit|
           if testunit.fail? || testunit.error?
-            list << testunit
+            list << [testcase, testunit]
           end
         end
       end
 
       unless list.empty? # or verbose?
         #report << "\n\n-- Failures and Errors --\n\n"
-        list.uniq.each do |testunit|
+        list.uniq.each do |(testcase, testunit)|
           heading = []
           message = []
           heading << (testunit.fail? ? FAIL : ERROR)
-          heading << testunit.name
+          heading << "#{testcase.name}::#{testunit.name}"
           message << heading.join(' ')
           message << testunit.message.tabto(2)
           message << clean_backtrace(testunit.backtrace).join("\n").tabto(2)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -90,6 +90,26 @@ HERE
 end
 
 #
+def setup_testunit_dotted
+  text = <<-HERE
+class DottedTest < Test::Unit::TestCase
+  def test_pass
+    assert_equal(1,1)
+  end
+
+  def test_fail
+    assert_equal(1,2)
+  end
+
+  def test_error
+    raise
+  end
+end
+  HERE
+  save_test(text, 'dotted_test.rb')
+end
+
+#
 def setup_testunit_outline
   text = <<-HERE
 class OutlineTest < Test::Unit::TestCase

--- a/test/test_reporters.rb
+++ b/test/test_reporters.rb
@@ -19,6 +19,14 @@ class TestReporters < Test::Unit::TestCase
     assert result.index('0 errors'), "ACTUAL RESULT:\n#{result}"
   end
 
+  def test_dotted_shows_name
+    file = setup_testunit_dotted
+    result = turn '--dotted', file
+    assert result.index('FAIL test_fail'), "ACTUAL RESULT:\n#{result}"
+    assert result.index('ERROR test_error'), "ACTUAL RESULT:\n#{result}"
+    assert !result.index('test_pass'), "ACTUAL RESULT:\n#{result}"
+  end
+
   def test_marshal
     file = setup_testunit
     result = turn '--marshal', file

--- a/test/test_reporters.rb
+++ b/test/test_reporters.rb
@@ -22,8 +22,8 @@ class TestReporters < Test::Unit::TestCase
   def test_dotted_shows_name
     file = setup_testunit_dotted
     result = turn '--dotted', file
-    assert result.index('FAIL test_fail'), "ACTUAL RESULT:\n#{result}"
-    assert result.index('ERROR test_error'), "ACTUAL RESULT:\n#{result}"
+    assert result.index('FAIL DottedTest::test_fail'), "ACTUAL RESULT:\n#{result}"
+    assert result.index('ERROR DottedTest::test_error'), "ACTUAL RESULT:\n#{result}"
     assert !result.index('test_pass'), "ACTUAL RESULT:\n#{result}"
   end
 


### PR DESCRIPTION
Dot formatter didn't show name of a failed test which made it hard to find
a failed example.

Fixes #118.
